### PR TITLE
Fix issue with answers not being saved anymore 

### DIFF
--- a/src/api/VotingIrregularities.Api/Controllers/Authorization.cs
+++ b/src/api/VotingIrregularities.Api/Controllers/Authorization.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using MediatR;
 using VotingIrregularities.Domain.UserAggregate;
 using VotingIrregularities.Api.Options;
+using VotingIrregularities.Api.Helpers;
 
 namespace VotingIrregularities.Api.Controllers
 {
@@ -68,7 +69,7 @@ namespace VotingIrregularities.Api.Controllers
         new Claim(JwtRegisteredClaimNames.Iat,
                   ToUnixEpochDate(_jwtOptions.IssuedAt).ToString(),
                   ClaimValueTypes.Integer64),
-        identity.FindFirst("IdObservator")
+        identity.FindFirst(ClaimsHelper._observerIdProperty)
       };
 
             // Create the JWT security token and encode it.
@@ -151,11 +152,11 @@ namespace VotingIrregularities.Api.Controllers
                     });
 
             return await Task.FromResult(new ClaimsIdentity(
-                new GenericIdentity(user.Phone, "Token"),
+                new GenericIdentity(user.Phone, ClaimsHelper._genericIdProvider),
                 new[]
                 {
-                    new Claim("Observator", "ONG"),
-                    new Claim("ObserverId", userInfo.ObserverId.ToString())
+                    new Claim(ClaimsHelper._observerProperty, ClaimsHelper._observerDefault),
+                    new Claim(ClaimsHelper._observerIdProperty, userInfo.ObserverId.ToString())
                 }));
         }
     }

--- a/src/api/VotingIrregularities.Api/Controllers/Raspuns.cs
+++ b/src/api/VotingIrregularities.Api/Controllers/Raspuns.cs
@@ -15,6 +15,7 @@ using Newtonsoft.Json;
 using VotingIrregularities.Api.Extensions;
 using VotingIrregularities.Api.Models;
 using VotingIrregularities.Domain.RaspunsAggregate.Commands;
+using VotingIrregularities.Api.Helpers;
 
 namespace VotingIrregularities.Api.Controllers
 {
@@ -56,7 +57,7 @@ namespace VotingIrregularities.Api.Controllers
             var command = await _mediator.Send(new RaspunsuriBulk(raspuns.Raspuns));
 
             // TODO[DH] get the actual IdObservator from token
-            command.IdObservator = int.Parse(User.Claims.First(c => c.Type == "IdObservator").Value);
+            command.IdObservator = int.Parse(User.Claims.First(c => c.Type == ClaimsHelper._observerIdProperty).Value);
 
             var result = await _mediator.Send(command);
 

--- a/src/api/VotingIrregularities.Api/Helpers/ClaimsHelper.cs
+++ b/src/api/VotingIrregularities.Api/Helpers/ClaimsHelper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace VotingIrregularities.Api.Helpers
+{
+    public class ClaimsHelper
+    {
+        public readonly static string _observerIdProperty = "ObserverId";
+        public readonly static string _observerProperty = "Observator";
+
+        public readonly static string _observerDefault = "ONG";
+
+        public readonly static string _genericIdProvider = "Token";
+    }
+}


### PR DESCRIPTION
Due to change in property name - the id of the observer was not retrieved from claims anymore, so the answers were not being saved anymore.

