### PR TITLE
Fix POST endpoint on Forms controller

### DIFF
--- a/src/api/VoteMonitor.Api.Form/Queries/AddFormQueryHandler.cs
+++ b/src/api/VoteMonitor.Api.Form/Queries/AddFormQueryHandler.cs
@@ -26,10 +26,36 @@ namespace VoteMonitor.Api.Form.Queries
             _mapper = mapper;
         }
 
-        protected override async Task<FormDTO> HandleCore(AddFormQuery message)
-        {
-            var newForm = _mapper.Map<Entities.Form>(message.Form);
+        protected override async Task<FormDTO> HandleCore(AddFormQuery message) {
+            var newForm = new Entities.Form {
+                Code = message.Form.Code,
+                CurrentVersion = message.Form.CurrentVersion,
+                Description = message.Form.Description
+            };
+
+            newForm.FormSections = new List<FormSection>();
+            foreach (var fs in message.Form.FormSections) {
+                var formSection = new FormSection { Code = fs.Code, Description = fs.Description };
+                formSection.Questions = new List<Question>();
+                foreach (var q in fs.Questions) {
+                    var question = new Question{ QuestionType = q.QuestionType, Hint = q.Hint, Text = q.Text };
+                    var optionsForQuestion = new List<OptionToQuestion>();
+                    foreach (var o in q.OptionsToQuestions)
+                        if (o.IdOption > 0) {
+                            var existingOption = _context.Options.FirstOrDefault(option => option.Id == o.IdOption);
+                            optionsForQuestion.Add(new OptionToQuestion { Option = existingOption });
+                        }
+                        else {
+                            optionsForQuestion.Add(_mapper.Map<OptionToQuestion>(o));
+                        }
+                    question.OptionsToQuestions = optionsForQuestion;
+                    formSection.Questions.Add(question);
+                }
+                newForm.FormSections.Add(formSection);
+            }
+
             _context.Forms.Add(newForm);
+
             await _context.SaveChangesAsync();
             message.Form.Id = newForm.Id;
             return message.Form;


### PR DESCRIPTION
**Allow saving question with existing options**
Usage example for POST /api/v1/forms
```
{
  "code": "X",
  "currentVersion": 1,
  "description": "description form X",
  "formSections": [
    {
      "code": "S1",
      "description": "Section 1",
      "questions": [
        {
          "questionType": 1,
          "text": "Question 1 ",
          "hint": "Question 1 hint",
          "optionsToQuestions": [
            {
              "text": "option 1",
              "isFreeText": true
            },
{
            "idOption": 16
            }
          ]
        }
      ]
    }
  ]
}
```
`Question 1` has 2 options: one will be added, one already exists (`"idOption":16`).