### PR TITLE
Import observers feature

### DIFF
--- a/src/api/VoteMonitor.Api.Core/Commands/UploadFileCommand.cs
+++ b/src/api/VoteMonitor.Api.Core/Commands/UploadFileCommand.cs
@@ -1,10 +1,12 @@
 ﻿using MediatR;
 using Microsoft.AspNetCore.Http;
+using VoteMonitor.Api.Core;
 
-namespace VoteMonitor.Api.Note.Commands
+namespace VoteMonitor.Api.Core.Commands
 {
     public class UploadFileCommand : IRequest<string>
     {
         public IFormFile File { get; set; }
+        public UploadType UploadType { get; set; }
     }
 }

--- a/src/api/VoteMonitor.Api.Core/Handlers/UploadFileHandler.cs
+++ b/src/api/VoteMonitor.Api.Core/Handlers/UploadFileHandler.cs
@@ -2,9 +2,9 @@
 using System.Threading.Tasks;
 using MediatR;
 using VoteMonitor.Api.Core.Services;
-using VoteMonitor.Api.Note.Commands;
+using VoteMonitor.Api.Core.Commands;
 
-namespace VoteMonitor.Api.Note.Handlers
+namespace VoteMonitor.Api.Core.Handlers
 {
     public class UploadFileHandler : AsyncRequestHandler<UploadFileCommand, string>
     {
@@ -24,7 +24,8 @@ namespace VoteMonitor.Api.Note.Handlers
             if (message.File != null)
                 return await _fileService.UploadFromStreamAsync(message.File.OpenReadStream(),
                     message.File.ContentType,
-                    Path.GetExtension(message.File.FileName));
+                    Path.GetExtension(message.File.FileName),
+                    message.UploadType);
 
             return string.Empty;
         }

--- a/src/api/VoteMonitor.Api.Core/Options/FileServiceOptions.cs
+++ b/src/api/VoteMonitor.Api.Core/Options/FileServiceOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace VotingIrregularities.Api.Options
+﻿using System.Collections.Generic;
+
+namespace VotingIrregularities.Api.Options
 {
     /// <summary>
     /// Options for defining the FileService implementation
@@ -14,6 +16,6 @@
         /// Only relevand when `Type`=`LocalFileService`.
         /// This will be a relative path (`\notes`). Make sure you configure your container persistent storage on this path
         /// </summary>
-        public string StoragePath { get; set; }
+        public Dictionary<string,string> StoragePaths { get; set; }
     }
 }

--- a/src/api/VoteMonitor.Api.Core/Services/BlobService.cs
+++ b/src/api/VoteMonitor.Api.Core/Services/BlobService.cs
@@ -5,6 +5,7 @@ using Microsoft.WindowsAzure.Storage.Blob;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using VoteMonitor.Api.Core;
 using VoteMonitor.Api.Core.Services;
 using VotingIrregularities.Api.Options;
 
@@ -30,7 +31,7 @@ namespace VoteMonitor.Api.Note.Services
         /// <summary>
         /// Uploads a file from a stream in azure blob storage
         /// </summary>
-        public async Task<string> UploadFromStreamAsync(Stream sourceStream, string mimeType, string extension)
+        public async Task<string> UploadFromStreamAsync(Stream sourceStream, string mimeType, string extension, UploadType uploadType)
         {
             // Get a reference to the container.
             var container = _client.GetContainerReference(_storageOptions.Value.Container);

--- a/src/api/VoteMonitor.Api.Core/Services/IFileService.cs
+++ b/src/api/VoteMonitor.Api.Core/Services/IFileService.cs
@@ -15,7 +15,7 @@ namespace VoteMonitor.Api.Core.Services
         /// <param name="mimeType"></param>
         /// <param name="extension"></param>
         /// <returns>the reference to the resource just uploaded</returns>
-        Task<string> UploadFromStreamAsync(Stream sourceStream, string mimeType, string extension);
+        Task<string> UploadFromStreamAsync(Stream sourceStream, string mimeType, string extension, UploadType uploadType);
 
         /// <summary>
         /// Initialize the file system before first usage

--- a/src/api/VoteMonitor.Api.Core/Services/LocalFileService.cs
+++ b/src/api/VoteMonitor.Api.Core/Services/LocalFileService.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using VoteMonitor.Api.Core;
 using VoteMonitor.Api.Core.Services;
 using VotingIrregularities.Api.Options;
 
@@ -22,10 +23,10 @@ namespace VoteMonitor.Api.Note.Services
         {
             _localFileOptions = options.Value;
         }
-        public Task<string> UploadFromStreamAsync(Stream sourceStream, string mimeType, string extension)
+        public Task<string> UploadFromStreamAsync(Stream sourceStream, string mimeType, string extension, UploadType uploadType)
         {
             // set name
-            var localFile = _localFileOptions.StoragePath + "\\" + Guid.NewGuid().ToString("N") + extension;
+            var localFile = _localFileOptions.StoragePaths[uploadType.ToString()] + "\\" + Guid.NewGuid().ToString("N") + extension;
 
             // save to local path
             using (var fileStream = File.Create(localFile))

--- a/src/api/VoteMonitor.Api.Core/UploadType.cs
+++ b/src/api/VoteMonitor.Api.Core/UploadType.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VoteMonitor.Api.Core {
+    public enum UploadType {
+        Notes,
+        Observers
+    }
+}

--- a/src/api/VoteMonitor.Api.Core/VoteMonitor.Api.Core.csproj
+++ b/src/api/VoteMonitor.Api.Core/VoteMonitor.Api.Core.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 </Project>

--- a/src/api/VoteMonitor.Api.Note/Controllers/NoteController.cs
+++ b/src/api/VoteMonitor.Api.Note/Controllers/NoteController.cs
@@ -11,6 +11,7 @@ using VoteMonitor.Api.Location.Queries;
 using VoteMonitor.Api.Note.Commands;
 using System.Collections.Generic;
 using VoteMonitor.Api.Note.Queries;
+using VoteMonitor.Api.Core.Commands;
 
 namespace VoteMonitor.Api.Note.Controllers
 {
@@ -58,7 +59,7 @@ namespace VoteMonitor.Api.Note.Controllers
                 return this.ResultAsync(HttpStatusCode.NotFound);
 
             var command = _mapper.Map<AddNoteCommand>(note);
-            var fileAddress = await _mediator.Send(new UploadFileCommand { File = file });
+            var fileAddress = await _mediator.Send(new UploadFileCommand { File = file, UploadType = UploadType.Notes });
 
             command.IdObserver = int.Parse(User.Claims.First(c => c.Type == ClaimsHelper.ObserverIdProperty).Value);
             command.AttachementPath = fileAddress;

--- a/src/api/VoteMonitor.Api.Note/VoteMonitor.Api.Note.csproj
+++ b/src/api/VoteMonitor.Api.Note/VoteMonitor.Api.Note.csproj
@@ -15,4 +15,7 @@
     <ProjectReference Include="..\VoteMonitor.Api.Location\VoteMonitor.Api.Location.csproj" />
     <ProjectReference Include="..\VotingIrregularities.Domain\VotingIrregularities.Domain.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Services\" />
+  </ItemGroup>
 </Project>

--- a/src/api/VoteMonitor.Api.Note/VoteMonitor.Api.Note.csproj
+++ b/src/api/VoteMonitor.Api.Note/VoteMonitor.Api.Note.csproj
@@ -15,7 +15,4 @@
     <ProjectReference Include="..\VoteMonitor.Api.Location\VoteMonitor.Api.Location.csproj" />
     <ProjectReference Include="..\VotingIrregularities.Domain\VotingIrregularities.Domain.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Services\" />
-  </ItemGroup>
 </Project>

--- a/src/api/VoteMonitor.Api.Observer/Commands/ImportObserversRequest.cs
+++ b/src/api/VoteMonitor.Api.Observer/Commands/ImportObserversRequest.cs
@@ -1,11 +1,11 @@
 ﻿using MediatR;
+using System.Collections.Generic;
+using VoteMonitor.Api.Observer.Models;
 
 namespace VoteMonitor.Api.Observer.Commands
 {
-    public class ImportObserversRequest : IRequest<int>
-    {
+    public class ImportObserversRequest : IRequest<int> {
         public int IdOng { get; set; }
-        public string FilePath { get; set; }
-        public int NameIndexInFile { get; set; }
+        public string FilePath { get;set;}
     }
 }

--- a/src/api/VoteMonitor.Api.Observer/Controllers/ObserverController.cs
+++ b/src/api/VoteMonitor.Api.Observer/Controllers/ObserverController.cs
@@ -42,7 +42,6 @@ namespace VoteMonitor.Api.Observer.Controllers {
 
         [HttpPost]
         [Route("import")]
-        [AllowAnonymous]
         public async Task<int> Import(IFormFile file, [FromForm] int ongId)
         {
             if (ongId <= 0) {

--- a/src/api/VoteMonitor.Api.Observer/Handlers/ObserverRequestsHandler.cs
+++ b/src/api/VoteMonitor.Api.Observer/Handlers/ObserverRequestsHandler.cs
@@ -32,16 +32,16 @@ namespace VoteMonitor.Api.Observer.Handlers
             return _context.Observers.Max(o => o.Id) + 1;
         }
 
-        public Task<int> Handle(ImportObserversRequest message, CancellationToken token)
+        public async Task<int> Handle(ImportObserversRequest message, CancellationToken token)
         {
-            var pathToFile = message.FilePath;
+           var pathToFile = message.FilePath;
             var counter = 0;
             var startId = GetMaxIdObserver();
 
-            using (var reader = File.OpenText(pathToFile))
+           using (var reader = File.OpenText(pathToFile))
             {
-                while (reader.Peek() >= 0)
-                {
+                 while (reader.Peek() >= 0) { 
+                
                     var fileContent = reader.ReadLine();
 
                     var data = fileContent.Split('\t');
@@ -52,16 +52,16 @@ namespace VoteMonitor.Api.Observer.Handlers
                         Id = startId + counter,
                         IdNgo = message.IdOng,
                         Phone = data[0],
-                        Name = data[message.NameIndexInFile],
+                        Name = data[2],
                         Pin = hashed
                     };
                     _context.Observers.Add(observer);
                     counter++;
                 }
-                _context.SaveChanges();
-            }
+                await _context.SaveChangesAsync();
+             }
 
-            return Task.FromResult(counter);
+            return counter;
         }
 
         public async Task<int> Handle(NewObserverCommand message, CancellationToken token)

--- a/src/api/VoteMonitor.Api.Observer/Handlers/ObserverRequestsHandler.cs
+++ b/src/api/VoteMonitor.Api.Observer/Handlers/ObserverRequestsHandler.cs
@@ -29,7 +29,10 @@ namespace VoteMonitor.Api.Observer.Handlers
 
         private int GetMaxIdObserver()
         {
-            return _context.Observers.Max(o => o.Id) + 1;
+            if(_context.Observers.Any())
+                return _context.Observers.Max(o => o.Id) + 1;
+
+            return 1;
         }
 
         public async Task<int> Handle(ImportObserversRequest message, CancellationToken token)

--- a/src/api/VotingIrregularities.Api/Extensions/AddFileUploadParams.cs
+++ b/src/api/VotingIrregularities.Api/Extensions/AddFileUploadParams.cs
@@ -10,21 +10,10 @@ namespace VotingIrregularities.Api.Extensions
         /// <inheritdoc />
         public void Apply(Operation operation, OperationFilterContext context)
         {
-            if (!string.Equals(operation.OperationId, "ApiV1NoteAtaseazaPost", StringComparison.CurrentCultureIgnoreCase))
-                return;
-
-            operation.Consumes.Add("application/form-data");
-            operation.Parameters = new IParameter[]
-            {
-                new NonBodyParameter
-                {
-
-                    Name = "file",
-                    In = "formData",
-                    Required = true,
-                    Type = "file"
-                }
-            };
+            if (operation.Tags[0] == "Observer" && operation.OperationId == "Import" ||
+                operation.Tags[0] == "Note" && operation.OperationId == "Upload") {
+                operation.Consumes.Add("application/form-data");
+            }
         }
     }
 }

--- a/src/api/VotingIrregularities.Api/Startup.cs
+++ b/src/api/VotingIrregularities.Api/Startup.cs
@@ -43,6 +43,7 @@ using VoteMonitor.Api.Note.Controllers;
 using VoteMonitor.Api.Note.Services;
 using VoteMonitor.Api.Form.Controllers;
 using VoteMonitor.Api.Core;
+using VoteMonitor.Api.Core.Handlers;
 
 namespace VotingIrregularities.Api
 {
@@ -423,6 +424,7 @@ namespace VotingIrregularities.Api
             yield return typeof(NoteController).GetTypeInfo().Assembly;
             yield return typeof(FormController).GetTypeInfo().Assembly;
             yield return typeof(AnswersController).GetTypeInfo().Assembly;
+            yield return typeof(UploadFileHandler).GetTypeInfo().Assembly;
             // just to identify VotingIrregularities.Domain assembly
         }
 

--- a/src/api/VotingIrregularities.Api/appsettings.json
+++ b/src/api/VotingIrregularities.Api/appsettings.json
@@ -21,7 +21,10 @@
   "DefaultCacheSeconds": 0,
    "FileServiceOptions": {
     "Type": "LocalFileService", /* LocalFileStorage for.. well.. local file storage. Anything else for Azure Blob Storage (until further implementations)*/
-    "StoragePath": "\\notes"
+    "StoragePaths": {
+      "Notes": "\\notes",
+      "Observers": "\\observers"
+    }
    },
   "HashOptions": {
     "Salt": "",


### PR DESCRIPTION
* Implemented the observer import feature
* Refactored file upload for reuse:
    * move file upload command/handler files to Api.Core project
    * add an `uploadType` parameter to differentiate between different upload types (so far there's notes and observers)
    * fix swagger file upload operation