### PR TITLE
Fix issues with counties endpoints

### DIFF
--- a/src/api/VoteMonitor.Api.County/Controllers/CountyController.cs
+++ b/src/api/VoteMonitor.Api.County/Controllers/CountyController.cs
@@ -85,7 +85,7 @@ namespace VoteMonitor.Api.County.Controllers
         }
 
         [HttpGet("{countyId}")]
-        [Authorize("Organizer")]
+        [Authorize("NgoAdmin")]
         [ProducesResponseType(typeof(CountyModel), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ErrorModel), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]

--- a/src/api/VoteMonitor.Api.County/Handlers/CountiesCommandHandler.cs
+++ b/src/api/VoteMonitor.Api.County/Handlers/CountiesCommandHandler.cs
@@ -163,8 +163,8 @@ namespace VoteMonitor.Api.County.Handlers
             try
             {
                 counties = await _context.Counties
+                    .OrderBy(c => c.Order)
                     .Select(x => _mapper.Map<CountyModel>(x))
-                    .OrderBy(c=>c.Order)
                     .ToListAsync(cancellationToken);
             }
             catch (Exception e)


### PR DESCRIPTION
Fix issues with counties endpoints #274 

GET /api/v1/county - returns 400 ; there is a problem with ordering counties
GET /api/v1/county/{countyId} - should be available for all ngo accounts, not only organizers
