### PR TITLE
Fix query

### DIFF
--- a/src/api/VoteMonitor.Api.Answer/Handlers/AnswersQueryHandler.cs
+++ b/src/api/VoteMonitor.Api.Answer/Handlers/AnswersQueryHandler.cs
@@ -59,7 +59,7 @@ namespace VoteMonitor.Api.Answer.Handlers
                 {
                     IdObserver = x.Key.IdObserver,
                     IdPollingStation = x.Key.IdPollingStation,
-                    PollingStation = x.Key.CountyCode + " " + x.Key.PollingStationNumber,
+                    PollingStation = x.Key.CountyCode + " " + x.Key.PollingStationNumber.ToString(),
                     ObserverName = x.Key.ObserverName,
                     LastModified = x.Max(a => a.LastModified)
                 });


### PR DESCRIPTION
In order to concatenate on db side we should explicitly cas to string in order to prevent EF to map to addition