### PR TITLE
Implementation of POST ​/api​/v1​/observer​/removeDeviceId

### DIFF
--- a/src/api/VoteMonitor.Api.Observer/Commands/RemoveDeviceIdCommand.cs
+++ b/src/api/VoteMonitor.Api.Observer/Commands/RemoveDeviceIdCommand.cs
@@ -1,0 +1,21 @@
+﻿using MediatR;
+using AutoMapper;
+using VoteMonitor.Api.Observer.Models;
+
+namespace VoteMonitor.Api.Observer.Commands
+{
+    public class RemoveDeviceIdCommand : IRequest<bool>
+    {
+        public int IdObserver { get; set; }
+    }
+
+    public class RemoveDeviceIdProfile : Profile
+    {
+        public RemoveDeviceIdProfile()
+        {
+            CreateMap<RemoveDeviceIdModel, RemoveDeviceIdCommand>()
+                .ForMember(dest => dest.IdObserver, c => c.MapFrom(src => src.IdObserver))
+                ;
+        }
+    }
+}

--- a/src/api/VoteMonitor.Api.Observer/Commands/RemoveDeviceIdCommand.cs
+++ b/src/api/VoteMonitor.Api.Observer/Commands/RemoveDeviceIdCommand.cs
@@ -1,21 +1,9 @@
 ﻿using MediatR;
-using AutoMapper;
-using VoteMonitor.Api.Observer.Models;
 
 namespace VoteMonitor.Api.Observer.Commands
 {
-    public class RemoveDeviceIdCommand : IRequest<bool>
+    public class RemoveDeviceIdCommand : IRequest
     {
-        public int IdObserver { get; set; }
-    }
-
-    public class RemoveDeviceIdProfile : Profile
-    {
-        public RemoveDeviceIdProfile()
-        {
-            CreateMap<RemoveDeviceIdModel, RemoveDeviceIdCommand>()
-                .ForMember(dest => dest.IdObserver, c => c.MapFrom(src => src.IdObserver))
-                ;
-        }
+        public int Id { get; set; }
     }
 }

--- a/src/api/VoteMonitor.Api.Observer/Commands/RemoveDeviceIdCommand.cs
+++ b/src/api/VoteMonitor.Api.Observer/Commands/RemoveDeviceIdCommand.cs
@@ -1,9 +1,19 @@
 ﻿using MediatR;
+using AutoMapper;
+using VoteMonitor.Api.Observer.Models;
 
 namespace VoteMonitor.Api.Observer.Commands
 {
     public class RemoveDeviceIdCommand : IRequest
     {
         public int Id { get; set; }
+    }
+    
+    public class RemoveDeviceIdProfile : Profile
+    {
+        public RemoveDeviceIdProfile()
+        {
+            CreateMap<RemoveDeviceIdModel, RemoveDeviceIdCommand>();
+        }
     }
 }

--- a/src/api/VoteMonitor.Api.Observer/Controllers/ObserverController.cs
+++ b/src/api/VoteMonitor.Api.Observer/Controllers/ObserverController.cs
@@ -165,17 +165,25 @@ namespace VoteMonitor.Api.Observer.Controllers
         [HttpPost]
         [Route("removeDeviceId")]
         [Authorize("NgoAdmin")]
-        [Produces(type: typeof(bool))]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> RemoveObserverDeviceId(int id)
         {
-            if (!ModelState.IsValid)
+            var observerRequest = new CheckObserverExists
             {
-                return BadRequest(ModelState);
+                Id = id
+            };
+
+            var foundObserver = await _mediator.Send(observerRequest);
+            if (!foundObserver)
+            {
+                return NotFound(id);
             }
 
-            var result = await _mediator.Send(_mapper.Map<RemoveDeviceIdCommand>(new RemoveDeviceIdModel { IdObserver = id }));
+            var request = _mapper.Map<RemoveDeviceIdCommand>(new RemoveDeviceIdModel {Id = id});
+            await _mediator.Send(request);
 
-            return Ok(result);
+            return Ok();
         }
 
         [HttpPost]
@@ -234,7 +242,7 @@ namespace VoteMonitor.Api.Observer.Controllers
         {
             if (!ControllerExtensions.ValidateGenerateObserversNumber(count))
             {
-                return BadRequest("Incorrect parameter supplied, please check that paramter is between boundaries: "
+                return BadRequest("Incorrect parameter supplied, please check that parameter is between boundaries: "
                     + ControllerExtensions.LOWER_OBS_VALUE + " - " + ControllerExtensions.UPPER_OBS_VALUE);
             }
 

--- a/src/api/VoteMonitor.Api.Observer/Controllers/ObserverController.cs
+++ b/src/api/VoteMonitor.Api.Observer/Controllers/ObserverController.cs
@@ -157,6 +157,27 @@ namespace VoteMonitor.Api.Observer.Controllers
             return Ok(result);
         }
 
+        /// <summary>
+        /// Removes mobile device Id associated with Observer of given Id.
+        /// </summary>
+        /// <param name="id">The Observer id</param>
+        /// <returns>Boolean indicating whether or not the mobile device Id was removed successfully</returns>
+        [HttpPost]
+        [Route("removeDeviceId")]
+        [Authorize("NgoAdmin")]
+        [Produces(type: typeof(bool))]
+        public async Task<IActionResult> RemoveObserverDeviceId(int id)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var result = await _mediator.Send(_mapper.Map<RemoveDeviceIdCommand>(new RemoveDeviceIdModel { IdObserver = id }));
+
+            return Ok(result);
+        }
+
         [HttpPost]
         [Route("reset")]
         [Authorize("Organizer")]

--- a/src/api/VoteMonitor.Api.Observer/Handlers/CheckObserverExistsHandler.cs
+++ b/src/api/VoteMonitor.Api.Observer/Handlers/CheckObserverExistsHandler.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using VoteMonitor.Api.Observer.Queries;
+using VoteMonitor.Entities;
+
+namespace VoteMonitor.Api.Observer.Handlers
+{
+    public class CheckObserverExistsHandler : IRequestHandler<CheckObserverExists, bool>
+    {
+        private readonly VoteMonitorContext _context;
+        private readonly ILogger _logger;
+
+        public CheckObserverExistsHandler(VoteMonitorContext context, ILogger<CheckObserverExistsHandler> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<bool> Handle(CheckObserverExists request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await _context.Observers.AnyAsync(p => p.Id == request.Id, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Error retrieving observer: ", ex);
+                throw;
+            }
+        }
+    }
+}

--- a/src/api/VoteMonitor.Api.Observer/Handlers/RemoveDeviceIdHandler.cs
+++ b/src/api/VoteMonitor.Api.Observer/Handlers/RemoveDeviceIdHandler.cs
@@ -4,50 +4,43 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using VoteMonitor.Api.Observer.Commands;
 using VoteMonitor.Entities;
 
 namespace VoteMonitor.Api.Observer.Handlers
 {
-    public class RemoveDeviceIdHandler : IRequestHandler<RemoveDeviceIdCommand, bool>
+    public class RemoveDeviceIdHandler : IRequestHandler<RemoveDeviceIdCommand>
     {
-        private readonly VoteMonitorContext _voteMonitorContext;
+        private readonly VoteMonitorContext _context;
         private readonly ILogger _logger;
 
-        public RemoveDeviceIdHandler(VoteMonitorContext context, ILogger<ResetDeviceHandler> logger)
+        public RemoveDeviceIdHandler(VoteMonitorContext context, ILogger<RemoveDeviceIdHandler> logger)
         {
-            _voteMonitorContext = context;
+            _context = context;
             _logger = logger;
         }
 
-        public Task<bool> Handle(RemoveDeviceIdCommand request, CancellationToken cancellationToken)
+        public async Task<Unit> Handle(RemoveDeviceIdCommand request, CancellationToken cancellationToken)
         {
             try
             {
-                var observerQuery = _voteMonitorContext.Observers
-                    .Where(o => o.Id == request.IdObserver);
-
-                var observer = observerQuery.FirstOrDefault();
-
-                if (observer == null)
-                {
-                    return Task.FromResult(false);
-                }
+                var observer = _context.Observers
+                    .Where(o => o.Id == request.Id)
+                    .FirstAsync(cancellationToken)
+                    .Result;
 
                 observer.MobileDeviceId = null;
-
-                _voteMonitorContext.Update(observer);
-                _voteMonitorContext.SaveChangesAsync(cancellationToken);
-                return Task.FromResult(true);
+                await _context.SaveChangesAsync(cancellationToken);
+                return Unit.Value;
             }
             catch (Exception exception)
             {
                 _logger.LogError(
-                    "Exception caught during removal of mobile device Id of Observer with id " + request.IdObserver,
+                    "Exception caught during removal of mobile device Id of Observer with id " + request.Id,
                     exception);
+                throw;
             }
-
-            return Task.FromResult(false);
         }
     }
 }

--- a/src/api/VoteMonitor.Api.Observer/Handlers/RemoveDeviceIdHandler.cs
+++ b/src/api/VoteMonitor.Api.Observer/Handlers/RemoveDeviceIdHandler.cs
@@ -25,10 +25,9 @@ namespace VoteMonitor.Api.Observer.Handlers
         {
             try
             {
-                var observer = _context.Observers
+                var observer = await _context.Observers
                     .Where(o => o.Id == request.Id)
-                    .FirstAsync(cancellationToken)
-                    .Result;
+                    .FirstAsync(cancellationToken);
 
                 observer.MobileDeviceId = null;
                 await _context.SaveChangesAsync(cancellationToken);

--- a/src/api/VoteMonitor.Api.Observer/Handlers/RemoveDeviceIdHandler.cs
+++ b/src/api/VoteMonitor.Api.Observer/Handlers/RemoveDeviceIdHandler.cs
@@ -1,0 +1,53 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VoteMonitor.Api.Observer.Commands;
+using VoteMonitor.Entities;
+
+namespace VoteMonitor.Api.Observer.Handlers
+{
+    public class RemoveDeviceIdHandler : IRequestHandler<RemoveDeviceIdCommand, bool>
+    {
+        private readonly VoteMonitorContext _voteMonitorContext;
+        private readonly ILogger _logger;
+
+        public RemoveDeviceIdHandler(VoteMonitorContext context, ILogger<ResetDeviceHandler> logger)
+        {
+            _voteMonitorContext = context;
+            _logger = logger;
+        }
+
+        public Task<bool> Handle(RemoveDeviceIdCommand request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var observerQuery = _voteMonitorContext.Observers
+                    .Where(o => o.Id == request.IdObserver);
+
+                var observer = observerQuery.FirstOrDefault();
+
+                if (observer == null)
+                {
+                    return Task.FromResult(false);
+                }
+
+                observer.MobileDeviceId = null;
+
+                _voteMonitorContext.Update(observer);
+                _voteMonitorContext.SaveChangesAsync(cancellationToken);
+                return Task.FromResult(true);
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(
+                    "Exception caught during removal of mobile device Id of Observer with id " + request.IdObserver,
+                    exception);
+            }
+
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/api/VoteMonitor.Api.Observer/Models/RemoveDeviceIdModel.cs
+++ b/src/api/VoteMonitor.Api.Observer/Models/RemoveDeviceIdModel.cs
@@ -1,0 +1,7 @@
+﻿namespace VoteMonitor.Api.Observer.Models
+{
+    public class RemoveDeviceIdModel
+    {
+        public int IdObserver { get; set; }
+    }
+}

--- a/src/api/VoteMonitor.Api.Observer/Models/RemoveDeviceIdModel.cs
+++ b/src/api/VoteMonitor.Api.Observer/Models/RemoveDeviceIdModel.cs
@@ -2,6 +2,6 @@
 {
     public class RemoveDeviceIdModel
     {
-        public int IdObserver { get; set; }
+        public int Id { get; set; }
     }
 }

--- a/src/api/VoteMonitor.Api.Observer/Queries/CheckObserverExists.cs
+++ b/src/api/VoteMonitor.Api.Observer/Queries/CheckObserverExists.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace VoteMonitor.Api.Observer.Queries
+{
+    public class CheckObserverExists : IRequest<bool>
+    {
+        public int Id { get; set; }
+    }
+}


### PR DESCRIPTION
### What does it fix?

Closes #239

Adds the 'POST ​/api​/v1​/observer​/removeDeviceId' endpoint used to remove the MobileDeviceId associated with a given Observer.

### How has it been tested?

Tested manually through SwaggerUI since I couldn't find tests for the other Observer-related endpoints.