### PR TITLE
Fixed: #316 Import file should not be stored for observers

### DIFF
--- a/src/api/VoteMonitor.Api.Observer/Controllers/ObserverController.cs
+++ b/src/api/VoteMonitor.Api.Observer/Controllers/ObserverController.cs
@@ -79,13 +79,6 @@ namespace VoteMonitor.Api.Observer.Controllers
                 ongId = NgoId;
             }
 
-            await _mediator.Send(
-                new UploadFileCommand
-                {
-                    File = file,
-                    UploadType = UploadType.Observers
-                });
-
             var counter = await _mediator.Send(new ImportObserversRequest
             {
                 File = file,


### PR DESCRIPTION
Closes #316 

**Cause:**
That was the way it was implemented.

**Fixed:**
That I removed the sending of the command responsible to upload the file in the file storage.

**Tested:**
Manually: That the observers from the file are correctly imported and the file is not stored in the file storage.

Also, I noticed a possible issue if you import a list twice then the observers will be duplicated. What do we want in this case? 
 Option 1: Update them accordingly to the list.
 Option 2: Return some error.
I'll log a new issue for this. 