### PR TITLE
new github action build-push-action for docker development

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Publish Docker image
+
+on:
+
+  push:
+    branches:
+      - develop
+      - master
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ secrets.ORGANIZATION }}/${{ secrets.REPO }}:latest
+


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #270 

I added a build and publish workflow that triggers on pushes to master or develop. These will occur when pushing directly or when merging a pull request. Note that it won't occur if a pr is only created.
It will always push with the 'latest' tag

You will need to setup the following credentials as github secrets (similar to the example given):
ORGANIZATION - dockerhub organization
REPO - dockerhub image repository from the above organization (not sure if a new one needs to be created?)
USERNAME and PASSWORD for a user with access to these

You can find more information about the github action here: https://github.com/docker/build-push-action


<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->

<!-- If applicable, mention any known issues with the pull request -->
I used a private github repo for testing the secrets setup along side a private dockerhub repository.

There's an issue I encountered, however. This fails though I'm not sure why yet.. I'm not familiar with dotnet but I believe it may be due to invalid credentials setup?

```
RUN dotnet publish -c Release -o ./out
```

Results in this during the publish step, when building the image:
```
... executor failed running [/bin/sh -c dotnet publish -c Release -o ./out]: exit code: 1
```


Because of (or without the files generated from) the previous error, the following occurs on this step: 

```
COPY --from=build-env /app/api/VoteMonitor.Api/out/ .
```

Results in this during the publish step, when building the image:

```
... failed to compute cache key: "/app/api/VoteMonitor.Api/out" not found: not found
```
