### PR TITLE
Add Api Health checks

### DIFF
--- a/src/VotingIrregularities.sln
+++ b/src/VotingIrregularities.sln
@@ -48,6 +48,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VoteMonitor.Api.Tests", "test\VoteMonitor.Api.Tests\VoteMonitor.Api.Tests.csproj", "{C19B6C2B-D63C-426A-ADED-00C4F5B78929}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -126,6 +128,10 @@ Global
 		{674C9094-58B8-4749-9EB1-2FFD054B8D7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{674C9094-58B8-4749-9EB1-2FFD054B8D7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{674C9094-58B8-4749-9EB1-2FFD054B8D7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C19B6C2B-D63C-426A-ADED-00C4F5B78929}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C19B6C2B-D63C-426A-ADED-00C4F5B78929}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C19B6C2B-D63C-426A-ADED-00C4F5B78929}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C19B6C2B-D63C-426A-ADED-00C4F5B78929}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -149,6 +155,7 @@ Global
 		{DD341123-8FD7-4506-AA0D-4280A5112A6F} = {8A09B442-FB79-4293-BF9B-E34DD3AE70F3}
 		{C7767496-1BC5-41AD-98D1-439BAA2ACEAE} = {388C55EB-26FF-46AB-9395-549E1A7A99AD}
 		{674C9094-58B8-4749-9EB1-2FFD054B8D7D} = {8A09B442-FB79-4293-BF9B-E34DD3AE70F3}
+		{C19B6C2B-D63C-426A-ADED-00C4F5B78929} = {388C55EB-26FF-46AB-9395-549E1A7A99AD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AF1523BC-7F31-4564-8E1B-D2DB4552FFCB}

--- a/src/api/VoteMonitor.Api.Core/Services/CacheService.cs
+++ b/src/api/VoteMonitor.Api.Core/Services/CacheService.cs
@@ -12,7 +12,7 @@ namespace VoteMonitor.Api.Core.Services
         private readonly IDistributedCache _cache;
         private readonly ILogger _logger;
 
-        public CacheService(IDistributedCache cache, ILogger logger)
+        public CacheService(IDistributedCache cache, ILogger<CacheService> logger)
         {
             _cache = cache;
             _logger = logger;

--- a/src/api/VoteMonitor.Api/Extensions/HealthChecks/AzureBlobStorageHealthChecksExtensions.cs
+++ b/src/api/VoteMonitor.Api/Extensions/HealthChecks/AzureBlobStorageHealthChecksExtensions.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Auth;
+using Microsoft.WindowsAzure.Storage.Blob;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using VoteMonitor.Api.Core.Options;
+
+namespace VoteMonitor.Api.Extensions.HealthChecks
+{
+    public static class AzureBlobStorageHealthChecksExtensions
+    {
+        public static IHealthChecksBuilder AddAzureBlobStorage(this IHealthChecksBuilder builder, string name)
+            => builder.Add(new HealthCheckRegistration(
+                   name,
+                   sp => new AzureBlobStorageHealthCheck(sp.GetService<IOptionsSnapshot<BlobStorageOptions>>()), null, null, null));
+    }
+
+    public class AzureBlobStorageHealthCheck : IHealthCheck
+    {
+        private IOptions<BlobStorageOptions> _storageOptions;
+
+        public AzureBlobStorageHealthCheck(IOptions<BlobStorageOptions> storageOptions)
+        {
+            _storageOptions = storageOptions;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var credentials = new StorageCredentials(_storageOptions.Value.AccountName, _storageOptions.Value.AccountKey);
+                var blobClient = new CloudStorageAccount(credentials, _storageOptions.Value.UseHttps).CreateCloudBlobClient();
+
+                var serviceProperties = await blobClient.GetServicePropertiesAsync(
+                    new BlobRequestOptions(),
+                    operationContext: null,
+                    cancellationToken: cancellationToken);
+
+                var container = blobClient.GetContainerReference(_storageOptions.Value.Container);
+                await container.FetchAttributesAsync();
+
+                return HealthCheckResult.Healthy();
+            }
+            catch (Exception ex)
+            {
+                return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
+            }
+        }
+    }
+}

--- a/src/api/VoteMonitor.Api/Extensions/HealthChecks/ConditionalHealthCheck.cs
+++ b/src/api/VoteMonitor.Api/Extensions/HealthChecks/ConditionalHealthCheck.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VoteMonitor.Api.Extensions.HealthChecks
+{
+    public static class ConditionalHealthChecksExtensions
+    {
+        public static IHealthChecksBuilder CheckOnlyWhen(this IHealthChecksBuilder builder, string name, Func<bool> predicate)
+        {
+            builder.Services.Configure<HealthCheckServiceOptions>(options =>
+            {
+                var registration = options.Registrations.FirstOrDefault(c => c.Name == name);
+
+                if (registration == null)
+                {
+                    throw new InvalidOperationException($"A health check registration named `{name}` is not found in the health registrations list, so its conditional check cannot be configured. The registration must be added before configuring the conditional predicate.");
+                }
+
+                var factory = registration.Factory;
+                registration.Factory = sp => new ConditionalHealthCheck(
+                       () => factory(sp),
+                       predicate,
+                       sp.GetService<ILogger<ConditionalHealthCheck>>()
+                   );
+            });
+
+            return builder;
+        }
+    }
+
+    public class ConditionalHealthCheck : IHealthCheck
+    {
+        private const string NotChecked = "NotChecked";
+        private readonly Func<bool> _predicate;
+        private readonly ILogger<ConditionalHealthCheck> _logger;
+
+        public ConditionalHealthCheck(Func<IHealthCheck> healthCheckFactory,
+            Func<bool> predicate,
+            ILogger<ConditionalHealthCheck> logger)
+        {
+            HealthCheckFactory = healthCheckFactory;
+            _predicate = predicate;
+            _logger = logger;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            context.Registration.Tags.Remove(NotChecked);
+
+            if (!_predicate())
+            {
+                _logger.LogDebug("Healthcheck `{0}` will not be executed as its checking condition is not met.", context.Registration.Name);
+
+                context.Registration.Tags.Add(NotChecked);
+
+                return new HealthCheckResult(HealthStatus.Healthy, $"Health check on `{context.Registration.Name}` will not be evaluated " +
+                    $"as its checking condition is not met. This does not mean your dependency is healthy, " +
+                    $"but the health check operation on this dependency is not configured to be executed yet.");
+            }
+
+            return await HealthCheckFactory().CheckHealthAsync(context, cancellationToken);
+        }
+
+        internal Func<IHealthCheck> HealthCheckFactory { get; set; }
+    }
+}

--- a/src/api/VoteMonitor.Api/Extensions/HealthChecks/FirebaseHealthChecksExtensions.cs
+++ b/src/api/VoteMonitor.Api/Extensions/HealthChecks/FirebaseHealthChecksExtensions.cs
@@ -1,0 +1,44 @@
+﻿using FirebaseAdmin;
+using FirebaseAdmin.Auth;
+using Google.Apis.Auth.OAuth2;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VoteMonitor.Api.Extensions.HealthChecks
+{
+    public static class FirebaseHealthChecksExtensions
+    {
+        public static IHealthChecksBuilder AddFirebase(this IHealthChecksBuilder builder, string name)
+            => builder.Add(new HealthCheckRegistration(
+                   name,
+                   sp => new FirebaseHealthCheck(), null, null, null));
+    }
+
+    public class FirebaseHealthCheck : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (FirebaseApp.DefaultInstance == null)
+                {
+                    FirebaseApp.Create(new AppOptions()
+                    {
+                        Credential = GoogleCredential.GetApplicationDefault(),
+                    });
+                }
+
+                var defaultAuth = FirebaseAuth.DefaultInstance;
+
+                return Task.FromResult(HealthCheckResult.Healthy());
+            }
+            catch (Exception ex)
+            {
+                return Task.FromResult(new HealthCheckResult(context.Registration.FailureStatus, exception: ex));
+            }
+        }
+    }
+}

--- a/src/api/VoteMonitor.Api/Extensions/HealthChecksConfiguration.cs
+++ b/src/api/VoteMonitor.Api/Extensions/HealthChecksConfiguration.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace VoteMonitor.Api.Extensions
+{
+    public static class HealthChecksConfiguration
+    {
+        public static async Task WriteResponse(HttpContext context, HealthReport result, IWebHostEnvironment env)
+        {
+            context.Response.ContentType = "application/json; charset=utf-8";
+
+            var options = new JsonSerializerOptions
+            {               
+                IgnoreNullValues = true
+            };
+
+            using var stream = new MemoryStream();
+
+            var healthResponse = new
+            {
+                status = result.Status.ToString(),
+                totalDuration = result.TotalDuration.ToString(),
+                entries = result.Entries.Select(e => new
+                {
+                    name = e.Key,
+                    status = e.Value.Status.ToString(),
+                    tags = e.Value.Tags,
+                    description = e.Value.Description,
+                    data = env.IsDevelopment() && e.Value.Data?.Count > 0 ? e.Value.Data : null,
+                    exception = env.IsDevelopment() ? ExtractSerializableExceptionData(e.Value.Exception) : null
+                }).ToList()
+            };
+
+            await JsonSerializer.SerializeAsync(stream, healthResponse, healthResponse.GetType(), options);
+            var json = Encoding.UTF8.GetString(stream.ToArray());
+            
+            await context.Response.WriteAsync(json);
+
+            static object ExtractSerializableExceptionData(Exception exception)
+            {
+                if (exception == null)
+                {
+                    return exception;
+                }
+
+                return new
+                {
+                    type = exception.GetType().ToString(),
+                    message = exception.Message,
+                    stackTrace = exception.StackTrace,
+                    source = exception.Source,
+                    data = exception.Data?.Count > 0 ? exception.Data : null,
+                    innerException = exception.InnerException != null ? ExtractSerializableExceptionData(exception.InnerException) : null
+                };
+            };
+        }
+    }
+}

--- a/src/api/VoteMonitor.Api/Properties/launchSettings.json
+++ b/src/api/VoteMonitor.Api/Properties/launchSettings.json
@@ -20,7 +20,16 @@
     "VoteMonitor.Api": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "weatherforecast",
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    },
+    "VoteMonitor.Api HealthChecks": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "health",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/api/VoteMonitor.Api/Startup.cs
+++ b/src/api/VoteMonitor.Api/Startup.cs
@@ -1,21 +1,24 @@
 using AutoMapper;
 using MediatR;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Extensions.Logging;
+using System.Runtime.CompilerServices;
 using VoteMonitor.Api.Core.Extensions;
 using VoteMonitor.Api.Extensions;
+using VoteMonitor.Api.Form;
 using VoteMonitor.Api.Location.Services;
 using VoteMonitor.Entities;
-using VoteMonitor.Api.Form;
 
+[assembly: InternalsVisibleTo("VoteMonitor.Api.Tests")]
 namespace VoteMonitor.Api
 {
     public class Startup
@@ -49,6 +52,7 @@ namespace VoteMonitor.Api
             services.ConfigureSwagger();
             services.AddApplicationInsightsTelemetry();
             services.AddCachingService(Configuration);
+            services.AddHealthChecks(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -69,6 +73,10 @@ namespace VoteMonitor.Api
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapHealthChecks("/health", new HealthCheckOptions
+                {
+                    ResponseWriter = async (context, result) => await HealthChecksConfiguration.WriteResponse(context, result, env)
+                });
                 endpoints.MapControllers();
             });
         }
@@ -84,7 +92,7 @@ namespace VoteMonitor.Api
             yield return typeof(Form.Controllers.FormController).GetTypeInfo().Assembly;
             yield return typeof(Location.Controllers.PollingStationController).GetTypeInfo().Assembly;
             yield return typeof(Note.Controllers.NoteController).GetTypeInfo().Assembly;
-            yield return typeof(Notification.Controllers.NotificationController).GetTypeInfo().Assembly;            
+            yield return typeof(Notification.Controllers.NotificationController).GetTypeInfo().Assembly;
             yield return typeof(Observer.Controllers.ObserverController).GetTypeInfo().Assembly;
             yield return typeof(Statistics.Controllers.StatisticsController).GetTypeInfo().Assembly;
             yield return typeof(PollingStation.Controllers.PollingStationController).GetTypeInfo().Assembly;

--- a/src/api/VoteMonitor.Api/VoteMonitor.Api.csproj
+++ b/src/api/VoteMonitor.Api/VoteMonitor.Api.csproj
@@ -7,20 +7,25 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetcore.HealthChecks.Publisher.ApplicationInsights" Version="3.1.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="3.1.1" />
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="FirebaseAdmin" Version="1.9.2" />
     <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.9" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="5.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.0.0" />
+    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,6 +46,12 @@
 
   <ItemGroup>
     <WCFMetadata Include="Connected Services" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.*.json">
+      <CopyToOutputDirectory>CopyIfNewer</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <!-- <Target Name="PostBuild" AfterTargets="PostBuildEvent" >

--- a/src/test/VoteMonitor.Api.Tests/Extensions/ServiceExtensions_ConditionalChecksRegistrationsTests.cs
+++ b/src/test/VoteMonitor.Api.Tests/Extensions/ServiceExtensions_ConditionalChecksRegistrationsTests.cs
@@ -1,0 +1,186 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VoteMonitor.Api.Extensions;
+using VoteMonitor.Api.Extensions.HealthChecks;
+using Xunit;
+
+namespace VoteMonitor.Api.Tests.Extensions
+{
+    public class ServiceExtensions_ConditionalChecksRegistrationsTests
+    {
+        [Theory]
+        [InlineData("VoteMonitorContext")]
+        [InlineData("Redis")]
+        [InlineData("AzureBlobStorage")]
+        [InlineData("Firebase")]
+        public void RegistersRequiredChecks(string registrationName)
+        {
+            var serviceCollection = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+
+            serviceCollection.AddHealthChecks(configuration);
+
+            var sp = serviceCollection.BuildServiceProvider();
+            var registrations = sp.GetService<IOptions<HealthCheckServiceOptions>>().Value.Registrations;
+            registrations.Should().Contain(c => c.Name == registrationName);
+        }
+
+        [Fact]
+        public async Task WhenApplicationCacheOptionsImplementationIsRedis_ThenRedisIsChecked()
+        {
+            // Arrange
+            var healthCheckMock = new Mock<IHealthCheck>();
+            var serviceCollection = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                     { "ApplicationCacheOptions:Implementation", "RedisCache"}
+                })
+                .Build();
+            var (registration, conditionalHealthCheck) = ArrangeRegistration(healthCheckMock, serviceCollection, configuration, "Redis");
+
+            // Act
+            await conditionalHealthCheck.CheckHealthAsync(new HealthCheckContext
+            {
+                Registration = registration
+            });
+
+            // Assert
+            healthCheckMock.Verify(c => c.CheckHealthAsync(It.IsAny<HealthCheckContext>(), It.IsAny<CancellationToken>()), Times.Once());
+        }
+
+        [Fact]
+        public async Task WhenApplicationCacheOptionsImplementationIsNotRedis_ThenRedisIsNotChecked()
+        {
+            // Arrange
+            var healthCheckMock = new Mock<IHealthCheck>();
+            var serviceCollection = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .Build();
+            var (registration, conditionalHealthCheck) = ArrangeRegistration(healthCheckMock, serviceCollection, configuration, "Redis");
+
+            // Act
+            await conditionalHealthCheck.CheckHealthAsync(new HealthCheckContext
+            {
+                Registration = registration
+            });
+
+            // Assert
+            healthCheckMock.Verify(c => c.CheckHealthAsync(It.IsAny<HealthCheckContext>(), It.IsAny<CancellationToken>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task WhenFirebaseConnectionIsNotSet_ThenFirebaseIsNotChecked()
+        {
+            // Arrange
+            var healthCheckMock = new Mock<IHealthCheck>();
+            var serviceCollection = new ServiceCollection();
+            var configuration = new ConfigurationBuilder().Build();
+            var (registration, conditionalHealthCheck) = ArrangeRegistration(healthCheckMock, serviceCollection, configuration, "Firebase");
+
+            // Act
+            await conditionalHealthCheck.CheckHealthAsync(new HealthCheckContext
+            {
+                Registration = registration
+            });
+
+            // Assert
+            healthCheckMock.Verify(c => c.CheckHealthAsync(It.IsAny<HealthCheckContext>(), It.IsAny<CancellationToken>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task WhenFirebaseConnectionIsSet_ThenFirebaseIsChecked()
+        {
+            // Arrange
+            var healthCheckMock = new Mock<IHealthCheck>();
+            var serviceCollection = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                     { "FirebaseServiceOptions:ServerKey", "a valid server key"}
+                })
+                .Build();
+            var (registration, conditionalHealthCheck) = ArrangeRegistration(healthCheckMock, serviceCollection, configuration, "Firebase");
+
+            // Act
+            await conditionalHealthCheck.CheckHealthAsync(new HealthCheckContext
+            {
+                Registration = registration
+            });
+
+            // Assert
+            healthCheckMock.Verify(c => c.CheckHealthAsync(It.IsAny<HealthCheckContext>(), It.IsAny<CancellationToken>()), Times.Once());
+        }
+
+        [Fact]
+        public async Task WhenFileServiceLocalFileService_ThenAzureBlobStorageIsNotChecked()
+        {
+            // Arrange
+            var healthCheckMock = new Mock<IHealthCheck>();
+            var serviceCollection = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                 .AddInMemoryCollection(new Dictionary<string, string>()
+                {
+                     { "FileServiceOptions:Type", "LocalFileService"}
+                })
+                .Build();
+            var (registration, conditionalHealthCheck) = ArrangeRegistration(healthCheckMock, serviceCollection, configuration, "AzureBlobStorage");
+
+            // Act
+            await conditionalHealthCheck.CheckHealthAsync(new HealthCheckContext
+            {
+                Registration = registration
+            });
+
+            // Assert
+            healthCheckMock.Verify(c => c.CheckHealthAsync(It.IsAny<HealthCheckContext>(), It.IsAny<CancellationToken>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task WhenFileServiceNotLocalFileService_ThenAzureBlobStorageIsChecked()
+        {
+            // Arrange
+            var healthCheckMock = new Mock<IHealthCheck>();
+            var serviceCollection = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .Build();
+            var (registration, conditionalHealthCheck) = ArrangeRegistration(healthCheckMock, serviceCollection, configuration, "AzureBlobStorage");
+
+            // Act
+            await conditionalHealthCheck.CheckHealthAsync(new HealthCheckContext
+            {
+                Registration = registration
+            });
+
+            // Assert
+            healthCheckMock.Verify(c => c.CheckHealthAsync(It.IsAny<HealthCheckContext>(), It.IsAny<CancellationToken>()), Times.Once());
+        }
+
+        private static (HealthCheckRegistration registration, ConditionalHealthCheck healthCheck) ArrangeRegistration(Mock<IHealthCheck> healthCheckMock, ServiceCollection serviceCollection, IConfigurationRoot configuration, string name)
+        {
+            serviceCollection.AddTransient<ILogger<ConditionalHealthCheck>>(sp => NullLogger<ConditionalHealthCheck>.Instance);
+            serviceCollection.AddHealthChecks(configuration);
+
+            var sp = serviceCollection.BuildServiceProvider();
+            var regisrations = sp.GetService<IOptions<HealthCheckServiceOptions>>().Value.Registrations;
+            var registration = regisrations.First(c => c.Name == name);
+            var healthCheck = registration.Factory(sp);
+            healthCheck.Should().BeOfType(typeof(ConditionalHealthCheck));
+
+            var conditionalHealthCheck = healthCheck as ConditionalHealthCheck;
+            conditionalHealthCheck.HealthCheckFactory = () => healthCheckMock.Object;
+
+            return (registration, conditionalHealthCheck);
+        }
+    }
+}

--- a/src/test/VoteMonitor.Api.Tests/VoteMonitor.Api.Tests.csproj
+++ b/src/test/VoteMonitor.Api.Tests/VoteMonitor.Api.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\api\VoteMonitor.Api\VoteMonitor.Api.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- VotingMonitor health check
- Redis health check
- Windows Azure health check
- Firebase health check

Redis, Windows Azure, and Firebase are configured
to be checked only on specific conditions
that depends on their configuration settings

Runtime configuration changes are considered
so if you enable a health check while the
application is running, then this is executed
otherwise, the health check is tagged as not run

Health Check endpoint /health is customized to
include specific details for each health check

The health checks are published on Application Insights.

The /health endpoint is not protected, so it is publicly accessible. This could be a potential security issue as it exposes the API dependencies.

<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?

Closes #211 

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

Enabling/disabling a health check is unit-tested

I manually tested Redis and VotingContext checks only. I also tested the /health endpoint.
I did not test Firebase and Azure Blob Storage, so suggest someone that has these dependencies to test them.
I also did not test the integration with Application Insights. It should periodically push the health checks status to Application Insights
